### PR TITLE
Remove async from datastores

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "etl-core"
-version = "0.1.3"
+version = "0.1.5-a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/etl-core/Cargo.toml
+++ b/etl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etl-core"
-version = "0.1.5a"
+version = "0.1.5-a"
 authors = ["Yuri Titov <ytitov@gmail.com>"]
 edition = "2018"
 

--- a/etl-core/Cargo.toml
+++ b/etl-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "etl-core"
-version = "0.1.5-a"
+version = "0.1.6-a"
 authors = ["Yuri Titov <ytitov@gmail.com>"]
 edition = "2018"
 

--- a/etl-core/src/datastore/enumerate.rs
+++ b/etl-core/src/datastore/enumerate.rs
@@ -1,5 +1,4 @@
 use crate::datastore::*;
-use async_trait::async_trait;
 use futures_core::future::BoxFuture;
 use std::time::Duration;
 
@@ -12,7 +11,6 @@ pub struct EnumerateStream<S, O> {
     pub create: fn(&'_ S, usize) -> DataOutputItemResult<O>,
 }
 
-#[async_trait]
 impl<S: Send + Sync + 'static, O: DeserializeOwned + Debug + Send + Sync + 'static> DataSource<O>
     for EnumerateStream<S, O>
 {
@@ -20,7 +18,7 @@ impl<S: Send + Sync + 'static, O: DeserializeOwned + Debug + Send + Sync + 'stat
         format!("{}", &self.name)
     }
 
-    async fn start_stream(self: Box<Self>) -> Result<DataSourceTask<O>, DataStoreError> {
+    fn start_stream(self: Box<Self>) -> Result<DataSourceTask<O>, DataStoreError> {
         use tokio::sync::mpsc::channel;
         let (tx, rx): (_, Receiver<Result<DataSourceMessage<O>, DataStoreError>>) = channel(1);
         let create_func = self.create;
@@ -89,7 +87,6 @@ impl<S,O> EnumerateStreamAsync<S,O> {
     }
 }
 
-#[async_trait]
 impl<S: Send + Sync + 'static, O: DeserializeOwned + Debug + Send + Sync + 'static> DataSource<O>
     for EnumerateStreamAsync<S, O>
 {
@@ -97,7 +94,7 @@ impl<S: Send + Sync + 'static, O: DeserializeOwned + Debug + Send + Sync + 'stat
         format!("{}", &self.name)
     }
 
-    async fn start_stream(self: Box<Self>) -> Result<DataSourceTask<O>, DataStoreError> {
+    fn start_stream(self: Box<Self>) -> Result<DataSourceTask<O>, DataStoreError> {
         use tokio::sync::mpsc::channel;
         let (tx, rx): (_, Receiver<Result<DataSourceMessage<O>, DataStoreError>>) = channel(1);
         let create_func = self.create;

--- a/etl-core/src/datastore/fs.rs
+++ b/etl-core/src/datastore/fs.rs
@@ -29,14 +29,14 @@ impl<T: Serialize + DeserializeOwned + std::fmt::Debug + Send + Sync + 'static>
         format!("LocalFsDataSource-{}", &self.home)
     }
 
-    async fn start_stream(
+    fn start_stream(
         mut self: Box<Self>,
     ) -> Result<DataSourceTask<T>, DataStoreError> {
         use ReadContentOptions::*;
         let name = String::from("LocalFsDataSource");
         match self.read_content.clone() {
-            Json => self.start_stream_json::<T>(name).await,
-            Csv(options) => self.start_stream_csv::<T>(options, name).await,
+            Json => self.start_stream_json::<T>(name),
+            Csv(options) => self.start_stream_csv::<T>(options, name),
             Text => {
                 unimplemented!()
             }
@@ -133,7 +133,7 @@ impl LocalFsDataSource {
         }
     }
 
-    async fn start_stream_json<T>(
+    fn start_stream_json<T>(
         &mut self,
         name: String,
     ) -> Result<DataSourceTask<T>, DataStoreError>
@@ -197,7 +197,7 @@ impl LocalFsDataSource {
         Ok((rx, jh))
     }
 
-    async fn start_stream_csv<T>(
+    fn start_stream_csv<T>(
         &mut self,
         csv_options: CsvReadOptions,
         name: String,

--- a/etl-core/src/datastore/job_runner.rs
+++ b/etl-core/src/datastore/job_runner.rs
@@ -7,82 +7,70 @@ pub struct JRDataSource<I, O: Serialize + Debug + Send + Sync + 'static> {
     pub transformer: Box<dyn TransformHandler<I, O>>,
     pub job_name: String,
 }
-#[async_trait]
+
 impl<
         I: Serialize + DeserializeOwned + Debug + Send + Sync + 'static,
         O: Serialize + DeserializeOwned + Debug + Send + Sync + 'static,
     > DataSource<O> for JRDataSource<I, O>
 {
-
     fn name(&self) -> String {
         format!("JobRunner-{}", &self.job_name)
     }
 
-    async fn start_stream(
-        mut self: Box<Self>,
-    ) -> Result<DataSourceTask<O>, DataStoreError> {
+    fn start_stream(self: Box<Self>) -> Result<DataSourceTask<O>, DataStoreError> {
         use tokio::sync::mpsc::channel;
-        let (mut source_rx, source_stream_jh) = self.input_ds.start_stream().await?;
+        let (mut source_rx, source_stream_jh) = self.input_ds.start_stream()?;
         let (tx, rx) = channel(1);
         let transformer = self.transformer;
         let job_name = format!("JRDataSource job name: {}", &self.job_name);
-        let jh: JoinHandle<Result<DataSourceStats, DataStoreError>> =
-            tokio::spawn(async move {
-                let mut lines_scanned = 0_usize;
-                loop {
-                    use crate::job::handler::TransformOutput::*;
-                    match source_rx.recv().await {
-                        Some(Ok(DataSourceMessage::Data {
-                            source,
-                            content: item,
-                        })) => {
-                            lines_scanned += 1;
-                            match transformer
-                                .transform_item(
-                                    JobItemInfo::new((lines_scanned, &job_name)),
-                                    item,
-                                )
-                                .await
-                            {
-                                Ok(Some(Item(item_out))) => {
-                                    tx.send(Ok(DataSourceMessage::new(&source, item_out)))
-                                        .await
-                                        .map_err(|e| {
-                                            DataStoreError::send_error(&job_name, "", e)
-                                        })?
-                                }
-                                Ok(Some(List(_vec))) => {
-                                    panic!("Processing list not implemented")
-                                }
-                                Ok(None) => {}
-                                Err(er) => {
-                                    tx.send(Err(DataStoreError::TransformerError {
-                                        job_name: job_name.to_owned(),
-                                        error: er.to_string(),
-                                    }))
-                                    .await
-                                    .map_err(
-                                        |e| DataStoreError::send_error(&job_name, "", e),
-                                    )?;
-                                }
-                            };
-                        }
-                        Some(Err(val)) => {
-                            tx.send(Err(DataStoreError::Deserialize {
-                                message: val.to_string(),
-                                attempted_string: "Unknown".to_string(),
-                            }))
+        let jh: JoinHandle<Result<DataSourceStats, DataStoreError>> = tokio::spawn(async move {
+            let mut lines_scanned = 0_usize;
+            loop {
+                use crate::job::handler::TransformOutput::*;
+                match source_rx.recv().await {
+                    Some(Ok(DataSourceMessage::Data {
+                        source,
+                        content: item,
+                    })) => {
+                        lines_scanned += 1;
+                        match transformer
+                            .transform_item(JobItemInfo::new((lines_scanned, &job_name)), item)
                             .await
-                            .map_err(|e| DataStoreError::send_error(&job_name, "", e))?;
-                        }
-                        None => break,
-                    };
-                }
+                        {
+                            Ok(Some(Item(item_out))) => tx
+                                .send(Ok(DataSourceMessage::new(&source, item_out)))
+                                .await
+                                .map_err(|e| DataStoreError::send_error(&job_name, "", e))?,
+                            Ok(Some(List(_vec))) => {
+                                panic!("Processing list not implemented")
+                            }
+                            Ok(None) => {}
+                            Err(er) => {
+                                tx.send(Err(DataStoreError::TransformerError {
+                                    job_name: job_name.to_owned(),
+                                    error: er.to_string(),
+                                }))
+                                .await
+                                .map_err(|e| DataStoreError::send_error(&job_name, "", e))?;
+                            }
+                        };
+                    }
+                    Some(Err(val)) => {
+                        tx.send(Err(DataStoreError::Deserialize {
+                            message: val.to_string(),
+                            attempted_string: "Unknown".to_string(),
+                        }))
+                        .await
+                        .map_err(|e| DataStoreError::send_error(&job_name, "", e))?;
+                    }
+                    None => break,
+                };
+            }
 
-                source_stream_jh.await??;
+            source_stream_jh.await??;
 
-                Ok(DataSourceStats { lines_scanned })
-            });
+            Ok(DataSourceStats { lines_scanned })
+        });
         Ok((rx, jh))
     }
 }

--- a/etl-core/src/datastore/mock.rs
+++ b/etl-core/src/datastore/mock.rs
@@ -90,7 +90,7 @@ impl<T: Serialize + DeserializeOwned + Debug + Send + Sync + 'static> DataSource
         format!("MockJsonDataSource")
     }
 
-    async fn start_stream(self: Box<Self>) -> Result<DataSourceTask<T>, DataStoreError> {
+    fn start_stream(self: Box<Self>) -> Result<DataSourceTask<T>, DataStoreError> {
         use tokio::sync::mpsc::channel;
         use tokio::task::JoinHandle;
         // could make this configurable

--- a/etl-core/src/datastore/mock/mock_csv.rs
+++ b/etl-core/src/datastore/mock/mock_csv.rs
@@ -18,7 +18,6 @@ impl Default for MockCsvDataSource {
     }
 }
 
-#[async_trait]
 impl<T: Serialize + DeserializeOwned + std::fmt::Debug + Send + Sync + 'static>
     DataSource<T> for MockCsvDataSource
 {
@@ -26,9 +25,8 @@ impl<T: Serialize + DeserializeOwned + std::fmt::Debug + Send + Sync + 'static>
         format!("MockCsvDataSource-{}", &self.name)
     }
 
-    async fn start_stream(self: Box<Self>) -> Result<DataSourceTask<T>, DataStoreError> {
+    fn start_stream(self: Box<Self>) -> Result<DataSourceTask<T>, DataStoreError> {
         use tokio::sync::mpsc::channel;
-        use tokio::task::JoinHandle;
         let CsvReadOptions {
             delimiter,
             has_headers,

--- a/etl-core/src/datastore/mod.rs
+++ b/etl-core/src/datastore/mod.rs
@@ -85,11 +85,10 @@ pub trait SimpleStore<T: DeserializeOwned + Debug + 'static + Send>: Sync + Send
 
 use crate::job_manager::JobManagerRx;
 
-#[async_trait]
 pub trait DataSource<T: DeserializeOwned + Debug + 'static + Send>: Sync + Send {
     fn name(&self) -> String;
 
-    async fn start_stream(self: Box<Self>) -> Result<DataSourceTask<T>, DataStoreError>;
+    fn start_stream(self: Box<Self>) -> Result<DataSourceTask<T>, DataStoreError>;
 
     /// TODO: this is not integrated yet because this doesn't get the JobManagerChannel because I'm
     /// not completely convinced this is necessary.  After all, JobRunner can close the rx end of

--- a/etl-core/src/decoder.rs
+++ b/etl-core/src/decoder.rs
@@ -24,14 +24,13 @@ pub struct DecodedSource<T: DeserializeOwned + Debug + 'static + Send + Send> {
     ds_task_result: Result<DataSourceTask<T>, DataStoreError>,
 }
 
-#[async_trait]
 impl<T: DeserializeOwned + Debug + Send + Sync + 'static> DataSource<T>
     for DecodedSource<T>
 {
     fn name(&self) -> String {
         format!("DecodedSource-{}", &self.source_name)
     }
-    async fn start_stream(self: Box<Self>) -> Result<DataSourceTask<T>, DataStoreError> {
+    fn start_stream(self: Box<Self>) -> Result<DataSourceTask<T>, DataStoreError> {
         self.ds_task_result
     }
 }

--- a/etl-core/src/decoder/csv.rs
+++ b/etl-core/src/decoder/csv.rs
@@ -31,7 +31,7 @@ impl<T: DeserializeOwned + Debug + 'static + Send + Sync> DecodeStream<T> for Cs
 
         //let (mut source_rx, source_stream_jh) = source.start_stream().await?;
 
-        match source.start_stream().await {
+        match source.start_stream() {
             Ok((mut source_rx, source_stream_jh)) => {
                 let CsvReadOptions {
                     delimiter,

--- a/etl-core/src/job.rs
+++ b/etl-core/src/job.rs
@@ -269,7 +269,7 @@ impl JobRunner {
         } else {
             let input_name = input.name().to_string();
             // no need to wait on input JoinHandle
-            let (mut input_rx, _) = input.start_stream().await?;
+            let (mut input_rx, _) = input.start_stream()?;
             let (output_tx, output_jh) = output
                 .start_stream(self.job_manager_channel.clone())
                 .await?;
@@ -357,7 +357,7 @@ impl JobRunner {
     where
         I: DeserializeOwned + Serialize + Debug + Send + Sync + 'static,
     {
-        let (mut rx, source_stream_jh) = ds.start_stream().await?;
+        let (mut rx, source_stream_jh) = ds.start_stream()?;
         let stream_name = job_handler.name();
         self.job_state = self.load_job_state().await?;
 

--- a/etl-core/src/joins.rs
+++ b/etl-core/src/joins.rs
@@ -76,7 +76,7 @@ where
             return Err(e.into());
         }
         Ok(right_ds) => {
-            let (mut right_rx, _) = right_ds.start_stream().await?;
+            let (mut right_rx, _) = right_ds.start_stream()?;
             loop {
                 match right_rx.recv().await {
                     Some(Ok(DataSourceMessage::Data {
@@ -137,7 +137,6 @@ where
     Ok(num_read)
 }
 
-#[async_trait]
 impl<L, R> DataSource<(L, Option<R>)> for LeftJoin<'static, L, R>
 where
     R: DeserializeOwned + Debug + Clone + 'static + Send + Sync,
@@ -147,13 +146,13 @@ where
         format!("LeftJoin-{}", self.left_ds.name())
     }
 
-    async fn start_stream(
+    fn start_stream(
         self: Box<Self>,
     ) -> Result<DataSourceTask<(L, Option<R>)>, DataStoreError> {
         use tokio::sync::mpsc::channel;
         use tokio::task::JoinHandle;
         let (tx, rx) = channel(1);
-        let (mut left_rx, _) = self.left_ds.start_stream().await?;
+        let (mut left_rx, _) = self.left_ds.start_stream()?;
 
         let max_left_len = self.left_buf_len;
         let matching_func = self.is_match;

--- a/etl-core/src/splitter.rs
+++ b/etl-core/src/splitter.rs
@@ -22,7 +22,7 @@ impl<I: Serialize + DeserializeOwned + Debug + Send + Sync + 'static> DataSource
         format!("{}-DuplicatedDataSource", &self.name)
     }
 
-    async fn start_stream(self: Box<Self>) -> Result<DataSourceTask<I>, DataStoreError> {
+    fn start_stream(self: Box<Self>) -> Result<DataSourceTask<I>, DataStoreError> {
         use tokio::sync::mpsc::channel;
         let (fw_tx, fw_rx): (_, Receiver<Result<DataSourceMessage<I>, DataStoreError>>) =
             channel(1);
@@ -102,9 +102,7 @@ where
     }
     let jh: JoinHandle<Result<DataSourceStats, DataStoreError>> = tokio::spawn(async move {
         let (mut input_rx, input_jh) = data_source
-            .start_stream()
-            .await
-            .expect("error starting source stream");
+            .start_stream()?;
         let mut lines_scanned = 0_usize;
         loop {
             match input_rx.recv().await {

--- a/etl-s3/src/datastore.rs
+++ b/etl-s3/src/datastore.rs
@@ -44,11 +44,11 @@ impl<T: Serialize + DeserializeOwned + Debug + Send + Sync + 'static> DataSource
         format!("S3DataSource-{}", &self.s3_bucket)
     }
 
-    async fn start_stream(mut self: Box<Self>) -> Result<DataSourceTask<T>, DataStoreError> {
+    fn start_stream(mut self: Box<Self>) -> Result<DataSourceTask<T>, DataStoreError> {
         use ReadContentOptions::*;
         match self.read_content.clone() {
-            Json => self.start_stream_json::<T>().await,
-            Csv(options) => self.start_stream_csv::<T>(options).await,
+            Json => self.start_stream_json::<T>(),
+            Csv(options) => self.start_stream_csv::<T>(options),
             Text => {
                 unimplemented!()
             }
@@ -112,7 +112,7 @@ impl<T: Serialize + DeserializeOwned + Debug + Send + Sync + 'static> SimpleStor
 }
 
 impl S3DataSource {
-    async fn start_stream_json<T>(&mut self) -> Result<DataSourceTask<T>, DataStoreError>
+    fn start_stream_json<T>(&mut self) -> Result<DataSourceTask<T>, DataStoreError>
     where
         T: DeserializeOwned + Send + 'static,
     {
@@ -185,7 +185,7 @@ impl S3DataSource {
         Ok((rx, jh))
     }
 
-    async fn start_stream_csv<T>(
+    fn start_stream_csv<T>(
         &mut self,
         csv_options: CsvReadOptions,
     ) -> Result<DataSourceTask<T>, DataStoreError>


### PR DESCRIPTION
No reason to make the stream create methods be async when the resources could be created inside the task itself and fail as needed.